### PR TITLE
Properly restrict spell preparation 

### DIFF
--- a/SolastaMultiClass/Patches/SharedSpellcastingPatchers.cs
+++ b/SolastaMultiClass/Patches/SharedSpellcastingPatchers.cs
@@ -381,7 +381,7 @@ namespace SolastaMultiClass.Patches
         {
             internal static void Postfix(SpellRepertoirePanel __instance)
             {
-                if (!Main.Settings.EnableSharedSpellcasting || Main.Settings.TurnOffSpellPreparationRestrictions)
+                if (!Main.Settings.EnableSharedSpellCasting)
                     return;
 
                 //It would be nice to short-circuit here but since I'm setting the visibility of the subitems it needs to be redone every time since these subitems seem to be shared across 'tabs'
@@ -424,7 +424,7 @@ namespace SolastaMultiClass.Patches
                         //Don't hide the spell slot status so people can see how many slots they have even if they don't have spells of that level
                         if (child.TryGetComponent(typeof(SlotStatusTable), out Component unused))
                             continue;
-                        if(i > (maxLevelOfSpellcastingForClass + accountForCantripsInt) - 1)
+                        if(i > (maxLevelOfSpellcastingForClass + accountForCantripsInt) - 1 && !Main.Settings.TurnOffSpellPreparationRestrictions) //The toggle option needs to be here otherwise if you already had it on and opened a spell list it will mess things up potentially for all spellcasters
                             child.gameObject.SetActive(false);
                         else
                             child.gameObject.SetActive(true); //Need to set to true because when switching tabs the false from one spellcasting class is carried over.

--- a/SolastaMultiClass/Settings.cs
+++ b/SolastaMultiClass/Settings.cs
@@ -12,7 +12,7 @@ namespace SolastaMultiClass
         public int MaxAllowedClasses = 2;
         public bool ForceMinInOutPreReqs = true;
         public bool EnableSharedSpellCasting = true;
-        public bool TurnOffSpellPreparationRestrictions = true;
+        public bool TurnOffSpellPreparationRestrictions = false;
         public int SelectedDeity = 0;
 
         public const InputCommands.Id PLAIN_LEFT = (InputCommands.Id)22220003;

--- a/SolastaMultiClass/Settings.cs
+++ b/SolastaMultiClass/Settings.cs
@@ -12,6 +12,7 @@ namespace SolastaMultiClass
         public int maxAllowedClasses = 2;
         public bool ForceMinInOutPreReqs = true;
         public bool EnableSharedSpellcasting = true;
+        public bool TurnOffSpellPreparationRestrictions = true;
 
         public const InputCommands.Id PLAIN_LEFT = (InputCommands.Id)22220003;
         public const InputCommands.Id PLAIN_RIGHT = (InputCommands.Id)22220004;

--- a/SolastaMultiClass/Viewers/SettingsViewer.cs
+++ b/SolastaMultiClass/Viewers/SettingsViewer.cs
@@ -36,6 +36,12 @@ namespace SolastaMultiClass.Viewers
                 Main.Settings.EnableSharedSpellCasting = toggle;
             }
 
+            toggle = Main.Settings.TurnOffSpellPreparationRestrictions;
+            if (UI.Toggle("Turn off multiclass spell preparing restrictions", ref toggle, 0, UI.AutoWidth()))
+            {
+                Main.Settings.TurnOffSpellPreparationRestrictions = toggle;
+            }
+
             UI.Label("Deity when multi classing into a Cleric or Paladin");
 
             var deityTitles = GetDeityList().ToArray();


### PR DESCRIPTION
- Restricts characters being able to prepare spells when they shouldn't be able to.  E.g. A multiclass character of Wiz 2/Cleric 3 should only be able to prepare Level 1 Wizard spells max, and Level 2 Cleric spells max even though they have Level 3 slots.
- Adds an option to turn this restriction off in the mod settings (mostly in case it breaks somehow)
- Also fixes a bug where I noticed a Cleric was getting level 1 spells when selecting cantrips