### PR TITLE
Fix level up spell selection

### DIFF
--- a/SolastaMultiClass/Models/Deity.cs
+++ b/SolastaMultiClass/Models/Deity.cs
@@ -34,7 +34,11 @@ namespace SolastaMultiClass.Models
         {
             var hero = characterBuildingService.HeroCharacter;
 
-            if (selectedClass == Paladin && !hero.ClassesAndLevels.ContainsKey(Cleric) || selectedClass == Cleric && !hero.ClassesAndLevels.ContainsKey(Paladin))
+            //Should we consider just checking DeityDefinition for all classes that need a Deity?
+            //Currently AHWarlock abuses Deity and puts the subclasses under the Deity so that's why Warlock needs it right now.
+            if(string.Equals(selectedClass.Name, "AHWarlockClass") && hero.DeityDefinition == null)
+                characterBuildingService.AssignDeity(GetDeityFromIndex(Main.Settings.SelectedDeity));
+            else if (selectedClass == Paladin && !hero.ClassesAndLevels.ContainsKey(Cleric) || selectedClass == Cleric && !hero.ClassesAndLevels.ContainsKey(Paladin))
             {
                 characterBuildingService.AssignDeity(GetDeityFromIndex(Main.Settings.SelectedDeity));
             }

--- a/SolastaMultiClass/Patches/LevelUpSequencePatchers.cs
+++ b/SolastaMultiClass/Patches/LevelUpSequencePatchers.cs
@@ -106,8 +106,8 @@ namespace SolastaMultiClass.Patches
 
                 if (___selectedClass >= 0)
                 {
-                    __instance.CommonData.AttackModesPanel.Hide();
-                    __instance.CommonData.PersonalityMapPanel.Hide();
+                    __instance.CommonData.AttackModesPanel?.Hide();
+                    __instance.CommonData.PersonalityMapPanel?.Hide();
                 }
             }
         }


### PR DESCRIPTION
- Patched GetSpellFeature to get the spell feature for the current class leveling up. Previously it would just get the first spell feature. My initial class combo tests had this work fine as I was testing with classes that selected spells at level up as the first class so their spell feature was selected. Now it should always behave properly and show the proper spells to select from at level up no matter what multiclass combo is done.
- Fixed some bugs in CharacterStageSpellSelectionPanel refresh along with the GetSpellFeature changes
- Also added null checks for LevelUpSequencePatcher.  Sometimes when not completing a level up then creating a new character the __instance.CommonData.AttackModesPanel was null